### PR TITLE
Add inclusive param to occurrences method

### DIFF
--- a/RRuleSwift.podspec
+++ b/RRuleSwift.podspec
@@ -5,7 +5,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RRuleSwift'
-  s.version          = '0.5.1'
+  s.version          = '0.5.2'
   s.summary          = 'Swift rrule library for working with recurrence rules of calendar dates.'
   s.description      = <<-DESC
   Swift rrule library for working with recurrence rules of calendar dates.

--- a/Sources/Iterators.swift
+++ b/Sources/Iterators.swift
@@ -59,7 +59,7 @@ public extension RecurrenceRule {
   }
   
   @objc
-  func occurrences(between date: Date, and otherDate: Date, endless endlessRecurrenceCount: Int = Iterator.endlessRecurrenceCount) -> [Date] {
+  func occurrences(between date: Date, and otherDate: Date, inclusive: Bool, endless endlessRecurrenceCount: Int = Iterator.endlessRecurrenceCount) -> [Date] {
     guard let _ = JavaScriptBridge.rrulejs() else {
       return []
     }
@@ -71,7 +71,7 @@ public extension RecurrenceRule {
     
     let ruleJSONString = toJSONString(endless: endlessRecurrenceCount)
     let _ = Iterator.rruleContext?.evaluateScript("var rule = new RRule({ \(ruleJSONString) })")
-    guard let betweenOccurrences = Iterator.rruleContext?.evaluateScript("rule.between(new Date('\(beginDateJSON)'), new Date('\(untilDateJSON)'))").toArray() as? [Date] else {
+    guard let betweenOccurrences = Iterator.rruleContext?.evaluateScript("rule.between(new Date('\(beginDateJSON)'), new Date('\(untilDateJSON)'), \(inclusive))").toArray() as? [Date] else {
       return []
     }
     


### PR DESCRIPTION
This fixes a bug where the start and end date weren't included while iterating over the instances.